### PR TITLE
TaggedLink improvements

### DIFF
--- a/cms/example-campaign/src/index.html
+++ b/cms/example-campaign/src/index.html
@@ -39,7 +39,7 @@
                             <p>Visit along ancient routes only known by the native indians.</p>
                         </div>
                         <div>
-                           <a href="https://en.wikipedia.org/wiki/Monument_Valley" data-link-name="monument-valley-link">Read more</a>
+                           <a href="https://en.wikipedia.org/wiki/Monument_Valley" data-link-name="monument-valley-link"><span data-content-name="monument-valley-link-text">Read more</span></a>
                         </div>
                     </div>
                 </div>

--- a/dotnet/SDL.DXA.Modules.CampaignContent/Controllers/CampaignContentController.cs
+++ b/dotnet/SDL.DXA.Modules.CampaignContent/Controllers/CampaignContentController.cs
@@ -125,14 +125,14 @@ namespace SDL.DXA.Modules.CampaignContent.Controllers
                         var link = taggedLink.ComponentLink ?? taggedLink.Url;
 
                         element.Attr("href", link ?? "#");
-                        if (link != null && WebRequestContext.IsPreview)
+                        if (WebRequestContext.IsPreview)
                         {
-                            var fieldName = taggedLink.ComponentLink != null ? "componentLink" : "url";
+                            var fieldName = taggedLink.ComponentLink != null || string.IsNullOrWhiteSpace(taggedLink.Url) ? "componentLink" : "url";
                             string xpmMarkup =
                                  "<!-- Start Component Field: {\"XPath\":\"tcm:Metadata/custom:Metadata/custom:taggedLinks[" +
                                 index +
                                 "]/custom:" + fieldName + "[1]\"} -->";
-                            element.Before(xpmMarkup);
+                            element.Prepend(xpmMarkup);
                         }
                     }
                     index++;


### PR DESCRIPTION
Always insert xpm markup for links
 - In order to choose a component in XPM even if no component is chosen and url is empty
Always prefer componentLink before url (if url is null or empty)
  - This allows for a component to be chosen immediately in XPM if href attribute is left empty in html
Prepend instead of Before
  - Is nicer as is does not require the <a> to be located within and empty div
  - Drawback is innerHTML of <a> is replaced with <add internal link to content> if no component is chosen. As soon as a component is chosen, the innerHTML appears as normal 