### PR TITLE
Support for replacing the same target attribute in all sibling elements

### DIFF
--- a/dotnet/SDL.DXA.Modules.CampaignContent/Controllers/CampaignContentController.cs
+++ b/dotnet/SDL.DXA.Modules.CampaignContent/Controllers/CampaignContentController.cs
@@ -97,6 +97,16 @@ namespace SDL.DXA.Modules.CampaignContent.Controllers
                         if ( taggedProperty.Image != null )
                         {
                             propertyValue = propertyValue.Replace("%URL%", taggedProperty.Image.Url);
+
+                            if (element.Attr("data-property-sibling-replace") == "true")
+                            {
+                                foreach (var sibling in element.SiblingElements)
+                                {
+                                    var siblingPropertyValue = sibling.Attr(taggedProperty.Target) ?? string.Empty;
+                                    siblingPropertyValue = siblingPropertyValue.Replace("%URL%", taggedProperty.Image.Url);
+                                    sibling.Attr(taggedProperty.Target, siblingPropertyValue);
+                                }
+                            }
                         }
                         element.Attr(taggedProperty.Target, propertyValue ?? string.Empty);
 


### PR DESCRIPTION
With the new property "data-property-sibling-replace" set to "true", all siblings can have their attribute replaced as well. This covers this case:

<picture>
  <source srcset="%URL% media="(max-width: 599px)">
  <source srcset="%URL% media="(max-width: 1199px)">
  <source srcset="%URL% media="(max-width: 1939px)">
  <img data-property-name='img-1' data-property-target='srcset' data-property-sibling-replace='true' srcset="%URL%" />
</picture>